### PR TITLE
Remove unnecessary `if` statement.

### DIFF
--- a/spectator/core/models.py
+++ b/spectator/core/models.py
@@ -138,11 +138,7 @@ class ThumbnailModelMixin(models.Model):
         So we can tell whether it's changed in save().
         """
         super().__init__(*args, **kwargs)
-
-        if self.thumbnail:
-            self.__original_thumbnail_name = self.thumbnail.name
-        else:
-            self.__original_thumbnail_name = None
+        self.__original_thumbnail_name = self.thumbnail.name
 
     def save(self, *args, **kwargs):
         """


### PR DESCRIPTION
Even if there's no thumbnail, then `self.thumbnail.name` exists, and
is an empty string.

For #64